### PR TITLE
Feat/private metadata

### DIFF
--- a/cmd/vaasapi/vaasapi.go
+++ b/cmd/vaasapi/vaasapi.go
@@ -50,6 +50,8 @@ func newConfig() (*config.Vaas, config.Error) {
 		"encryption key for organization private keys in the db. Leave empty for no encryption")
 	cfg.API.GatewayUrl = *flag.String("gatewayUrl",
 		"https://api-dev.vocdoni.net", "url to use as gateway api endpoint")
+	cfg.API.GlobalMetaKey = *flag.String("globalMetaKey", "",
+		"encryption key for organization metadata keys in the db. Leave empty for no encryption")
 	cfg.API.MaxCensusSize = *flag.Uint64("maxCensusSize", 2<<32, "maximum size of a voter census")
 	cfg.API.Route = *flag.String("apiRoute", "/", "dvote API route")
 	cfg.API.ListenHost = *flag.String("listenHost", "0.0.0.0", "API endpoint listen address")
@@ -97,6 +99,7 @@ func newConfig() (*config.Vaas, config.Error) {
 	viper.BindPFlag("api.explorerVoteUrl", flag.Lookup("explorerVoteUrl"))
 	viper.BindPFlag("api.globalEntityKey", flag.Lookup("globalEntityKey"))
 	viper.BindPFlag("api.gatewayUrl", flag.Lookup("gatewayUrl"))
+	viper.BindPFlag("api.globalMetaKey", flag.Lookup("globalMetaKey"))
 	viper.BindPFlag("api.route", flag.Lookup("apiRoute"))
 	viper.BindPFlag("api.listenHost", flag.Lookup("listenHost"))
 	viper.BindPFlag("api.listenPort", flag.Lookup("listenPort"))

--- a/config/vaas.go
+++ b/config/vaas.go
@@ -29,6 +29,8 @@ type API struct {
 	AdminToken string
 	// GlobalEntityKey is the key used to encrypt entity private keys in the db
 	GlobalEntityKey string
+	// GlobalMetaKey is the key used to encrypt entity metadata keys in the db
+	GlobalMetaKey string
 	// ExplorerVoteUrl is the url for explorer vote packages
 	ExplorerVoteUrl string
 	// GatewayUrls to use for gateway api

--- a/database/database.go
+++ b/database/database.go
@@ -39,6 +39,7 @@ type Database interface {
 	CreateElection(integratorAPIKey, orgEthAddress, processID, encryptedMetadataKey []byte, title string, startDate, endDate time.Time, censusID uuid.NullUUID, startBlock, endBlock int, confidential, hiddenResults bool) (int, error)
 	GetElection(integratorAPIKey, orgEthAddress, processID []byte) (*types.Election, error)
 	GetElectionPublic(organizationEthAddress, processID []byte) (*types.Election, error)
+	GetElectionPrivate(organizationEthAddress, processID []byte) (*types.Election, error)
 	ListElections(integratorAPIKey, orgEthAddress []byte) ([]types.Election, error)
 	// Manage DB
 	Ping() error

--- a/database/database.go
+++ b/database/database.go
@@ -36,7 +36,7 @@ type Database interface {
 	ListOrganizations(integratorAPIKey []byte, filter *types.ListOptions) ([]types.Organization, error)
 	CountOrganizations(integratorAPIKey []byte) (int, error)
 	// Election
-	CreateElection(integratorAPIKey, orgEthAddress, processID []byte, title string, startDate, endDate time.Time, censusID uuid.NullUUID, startBlock, endBlock int, confidential, hiddenResults bool) (int, error)
+	CreateElection(integratorAPIKey, orgEthAddress, processID, encryptedMetadataKey []byte, title string, startDate, endDate time.Time, censusID uuid.NullUUID, startBlock, endBlock int, confidential, hiddenResults bool) (int, error)
 	GetElection(integratorAPIKey, orgEthAddress, processID []byte) (*types.Election, error)
 	GetElectionPublic(organizationEthAddress, processID []byte) (*types.Election, error)
 	ListElections(integratorAPIKey, orgEthAddress []byte) ([]types.Election, error)

--- a/database/pgsql/elections.go
+++ b/database/pgsql/elections.go
@@ -62,7 +62,7 @@ func (d *Database) GetElectionPublic(organizationEthAddress, processID []byte) (
 
 func (d *Database) GetElection(integratorAPIKey, orgEthAddress, processID []byte) (*types.Election, error) {
 	var election types.Election
-	selectIntegrator := `SELECT title, census_id, start_date, end_date, start_block, end_block, confidential, hidden_results, 
+	selectIntegrator := `SELECT metadata_priv_key, title, census_id, start_date, end_date, start_block, end_block, confidential, hidden_results, 
 							created_at, updated_at
 						FROM elections WHERE organization_eth_address =$1 AND integrator_api_key=$2
 									AND process_id=$3`

--- a/database/pgsql/elections.go
+++ b/database/pgsql/elections.go
@@ -10,7 +10,7 @@ import (
 	"go.vocdoni.io/api/types"
 )
 
-func (d *Database) CreateElection(integratorAPIKey, orgEthAddress, processID []byte, title string, startDate, endDate time.Time, censusID uuid.NullUUID, startBlock, endBlock int, confidential, hiddenResults bool) (int, error) {
+func (d *Database) CreateElection(integratorAPIKey, orgEthAddress, processID, encryptedMetadataKey []byte, title string, startDate, endDate time.Time, censusID uuid.NullUUID, startBlock, endBlock int, confidential, hiddenResults bool) (int, error) {
 
 	election := &types.Election{
 		OrgEthAddress:    orgEthAddress,
@@ -24,6 +24,7 @@ func (d *Database) CreateElection(integratorAPIKey, orgEthAddress, processID []b
 		EndBlock:         endBlock,
 		Confidential:     confidential,
 		HiddenResults:    hiddenResults,
+		MetadataPrivKey:  encryptedMetadataKey,
 		CreatedUpdated: types.CreatedUpdated{
 			CreatedAt: time.Now(),
 			UpdatedAt: time.Now(),
@@ -31,9 +32,9 @@ func (d *Database) CreateElection(integratorAPIKey, orgEthAddress, processID []b
 	}
 	// TODO: Calculate EntityID (consult go-dvote)
 	insert := `INSERT INTO elections
-			( organization_eth_address, integrator_api_key, process_id, title, census_id,
+			( organization_eth_address, integrator_api_key, process_id, metadata_priv_key, title, census_id,
 				start_date, end_date, start_block, end_block, confidential, hidden_results, created_at, updated_at)
-			VALUES ( :organization_eth_address, :integrator_api_key, :process_id, :title, :census_id,
+			VALUES ( :organization_eth_address, :integrator_api_key, :process_id, :metadata_priv_key, :title, :census_id,
 				:start_date, :end_date, :start_block, :end_block, :confidential, :hidden_results, :created_at, :updated_at)
 			RETURNING id`
 	result, err := d.db.NamedQuery(insert, election)

--- a/database/pgsql/elections.go
+++ b/database/pgsql/elections.go
@@ -60,6 +60,14 @@ func (d *Database) GetElectionPublic(organizationEthAddress, processID []byte) (
 	return &election, row.StructScan(&election)
 }
 
+func (d *Database) GetElectionPrivate(organizationEthAddress, processID []byte) (*types.Election, error) {
+	var election types.Election
+	selectIntegrator := `SELECT metadata_priv_key, title, census_id, start_date, end_date, start_block, end_block, confidential, hidden_results, integrator_api_key
+						FROM elections WHERE organization_eth_address=$1 AND process_id=$2`
+	row := d.db.QueryRowx(selectIntegrator, organizationEthAddress, processID)
+	return &election, row.StructScan(&election)
+}
+
 func (d *Database) GetElection(integratorAPIKey, orgEthAddress, processID []byte) (*types.Election, error) {
 	var election types.Election
 	selectIntegrator := `SELECT metadata_priv_key, title, census_id, start_date, end_date, start_block, end_block, confidential, hidden_results, 

--- a/example/index.ts
+++ b/example/index.ts
@@ -7,6 +7,7 @@ import { fakeSign } from "./sections/fake-csp"
 
 async function main() {
     const encryptedResults = false
+    const confidential = true
 
     // VOCDONI INTERNAL
 
@@ -21,8 +22,9 @@ async function main() {
     await setOrganizationMetadata(organizationId, integratorApiKey)
     await getOrganizationPriv(organizationId, integratorApiKey)
 
-    const { electionId: electionId1 } = await createSignedElection(organizationId, encryptedResults, integratorApiKey)
-    // const { electionId: electionId2 } = await createAnonymousElection(organizationId, encryptedResults, integratorApiKey)
+    const { electionId: electionId1 } = await createSignedElection(organizationId, encryptedResults, confidential, integratorApiKey)
+    // const { electionId: electionId2 } = await createAnonymousElection(organizationId, encryptedResults, confidential, integratorApiKey)
+    await wait(11)
     // const electionList = await listElectionsPriv(organizationId, integratorApiKey)
     const election1Details = await getElectionPriv(electionId1, integratorApiKey)
     // const election2Details = await getElectionPriv(electionId2, integratorApiKey)
@@ -40,7 +42,8 @@ async function main() {
     // key for confidential election data
     // const cspSharedKey = await getElectionSharedKey(electionId1, signedElectionId, orgApiToken)
     const cspSharedKey = await getElectionSharedKeyCustom(electionId1, { voterId, signature }, orgApiToken)
-    // const electionInfo1 = await getElectionSecretInfoPub(electionId1, cspSharedKey, orgApiToken)
+    // const electionInfo2 = await getElectionSecretInfoPub(electionId2, cspSharedKey, orgApiToken)
+    const election1Details2 = await getElectionSecretInfoPub(electionId1, cspSharedKey, orgApiToken)
 
     // NON ANONYMOUS AUTH
     // const tokenR = await getCspSigningTokenPlain(electionId1, signedElectionId, orgApiToken)
@@ -56,7 +59,6 @@ async function main() {
     const blindSignature = await getCspBlindSignature(electionId1, tokenR, blindedPayload, orgApiToken)
     const proof = getProofFromBlindSignature(blindSignature, userSecretData, wallet)
 
-    // const encryptedResults = true
     const ballot = getBallotPayload(electionId1, proof, encryptedResults, election1Details.encryptionPubKeys)
 
     const { nullifier } = await submitBallot(electionId1, ballot, wallet, orgApiToken)
@@ -64,7 +66,7 @@ async function main() {
 
     // cleanup
 
-    await deleteOrganization(organizationId, integratorId)
+    await deleteOrganization(organizationId, integratorApiKey)
     await deleteIntegrator(integratorId)
 }
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -60,7 +60,8 @@ async function main() {
     const proof = getProofFromBlindSignature(blindSignature, userSecretData, wallet)
 
     const ballot = getBallotPayload(electionId1, proof, encryptedResults, election1Details.encryptionPubKeys)
-
+    
+    await wait(35)
     const { nullifier } = await submitBallot(electionId1, ballot, wallet, orgApiToken)
     const ballotDetails = await getBallot(nullifier, orgApiToken)
 

--- a/example/sections/integrator.ts
+++ b/example/sections/integrator.ts
@@ -151,6 +151,7 @@ export async function setOrganizationMetadata(id: string, apiKey: string) {
 }
 
 export async function createSignedElection(organizationId: string, hiddenResults: boolean, confidential: boolean, apiKey: string) {
+  console.log("Creating election...")
   const url = config.apiUrlPrefix + "/v1/priv/organizations/" + organizationId + "/elections/signed"
 
   const startDate = new Date(Date.now() + 1000 * 60) // start time should be at least one minute from 'now()'
@@ -279,11 +280,12 @@ type ElectionSummary = {
   endDate: string
 }
 export async function listElectionsPriv(organizationId: string, apiKey: string): Promise<Array<ElectionSummary>> {
-  const url = config.apiUrlPrefix + "/v1/priv/organizations/" + organizationId + "/elections/signed"
-  // const url = config.apiUrlPrefix + "/v1/priv/organizations/" + organizationId + "/elections/blind"
+  const url = config.apiUrlPrefix + "/v1/priv/organizations/" + organizationId + "/elections"
+  // const url = config.apiUrlPrefix + "/v1/priv/organizations/" + organizationId + "/elections/upcoming"
   // const url = config.apiUrlPrefix + "/v1/priv/organizations/" + organizationId + "/elections/active"
   // const url = config.apiUrlPrefix + "/v1/priv/organizations/" + organizationId + "/elections/ended"
-  // const url = config.apiUrlPrefix + "/v1/priv/organizations/" + organizationId + "/elections/ended"
+  // const url = config.apiUrlPrefix + "/v1/priv/organizations/" + organizationId + "/elections/signed"
+  // const url = config.apiUrlPrefix + "/v1/priv/organizations/" + organizationId + "/elections/blind"
 
   const response = await fetch(url, {
     headers: {

--- a/example/sections/integrator.ts
+++ b/example/sections/integrator.ts
@@ -150,7 +150,7 @@ export async function setOrganizationMetadata(id: string, apiKey: string) {
   return { apiToken, name, description, header, avatar }
 }
 
-export async function createSignedElection(organizationId: string, hiddenResults: boolean, apiKey: string) {
+export async function createSignedElection(organizationId: string, hiddenResults: boolean, confidential: boolean, apiKey: string) {
   const url = config.apiUrlPrefix + "/v1/priv/organizations/" + organizationId + "/elections/signed"
 
   const startDate = new Date(Date.now() + 1000 * 60) // start time should be at least one minute from 'now()'
@@ -175,7 +175,7 @@ export async function createSignedElection(organizationId: string, hiddenResults
         choices: ["Yes", "No", "Maybe", "Blank"]
       },
     ],
-    confidential: false,  // Metadata access restricted to only census members
+    confidential: confidential,  // Metadata access restricted to only census members
     hiddenResults, // Encrypt results until the process ends
     census: ""     // Empty when using a custom CSP
   }
@@ -210,7 +210,7 @@ export async function createSignedElection(organizationId: string, hiddenResults
   return { electionId }
 }
 
-export async function createAnonymousElection(organizationId: string, hiddenResults: boolean, apiKey: string) {
+export async function createAnonymousElection(organizationId: string, hiddenResults: boolean, confidential: boolean, apiKey: string) {
   const url = config.apiUrlPrefix + "/v1/priv/organizations/" + organizationId + "/elections/blind"
 
   const startDate = new Date(Date.now() + 1000 * 60) // start time should be at least one minute from 'now()'
@@ -235,7 +235,7 @@ export async function createAnonymousElection(organizationId: string, hiddenResu
         choices: ["Yes", "No", "Maybe", "Blank"]
       },
     ],
-    confidential: false,  // Metadata access restricted to only census members
+    confidential: confidential,  // Metadata access restricted to only census members
     hiddenResults, // Encrypt results until the process ends
     census: ""     // Empty when using a custom CSP
   }

--- a/example/sections/voter.ts
+++ b/example/sections/voter.ts
@@ -92,6 +92,10 @@ type ElectionDetail = {
   status: "READY" | "ENDED" | "CANCELED" | "PAUSED" | "RESULTS",
   voteCount: number,
   results: Array<Array<{ title: string, value: string }>> // Empty arrays when no results []
+  encryptionPubKeys: {
+    idx: number;
+    key: string;
+  }[]
 }
 export async function getElectionInfoPub(electionId: string, orgApiToken: string) {
   const url = config.apiUrlPrefix + "/v1/pub/elections/" + electionId
@@ -117,7 +121,7 @@ export async function getElectionInfoPub(electionId: string, orgApiToken: string
   return responseBody as ElectionDetail
 }
 
-export async function getElectionSecretInfoPub(electionId: string, cspSharedKey: string, orgApiToken: string) {
+export async function getElectionSecretInfoPub(electionId: string, cspSharedKey: string, orgApiToken: string): Promise<ElectionDetail> {
   const url = config.apiUrlPrefix + "/v1/pub/elections/" + electionId + "/auth/" + cspSharedKey
 
   const response = await fetch(url, {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module go.vocdoni.io/api
 go 1.16
 
 require (
+	github.com/arnaucube/go-blindsecp256k1 v0.0.0-20210323162413-ccaa6313370d
 	github.com/cockroachdb/apd v1.1.0 // indirect
 	github.com/ethereum/go-ethereum v1.10.13
 	github.com/frankban/quicktest v1.13.0
@@ -20,7 +21,6 @@ require (
 	go.vocdoni.io/proto v1.13.3-0.20211202161242-17ea8a435be6
 	golang.org/x/crypto v0.0.0-20210920023735-84f357641f63
 	google.golang.org/protobuf v1.27.1
-	nhooyr.io/websocket v1.8.7 // indirect
 )
 
 // Newer versions of the fuse module removed support for MacOS.

--- a/go.sum
+++ b/go.sum
@@ -391,7 +391,6 @@ github.com/ethereum/go-ethereum v1.9.20/go.mod h1:JSSTypSMTkGZtAdAChH2wP5dZEvPGh
 github.com/ethereum/go-ethereum v1.9.23/go.mod h1:JIfVb6esrqALTExdz9hRYvrP0xBDf6wCncIu1hNwHpM=
 github.com/ethereum/go-ethereum v1.9.25/go.mod h1:vMkFiYLHI4tgPw4k2j4MHKoovchFE8plZ0M9VMk4/oM=
 github.com/ethereum/go-ethereum v1.9.26-0.20201212163632-00d10e610f9f/go.mod h1:vMkFiYLHI4tgPw4k2j4MHKoovchFE8plZ0M9VMk4/oM=
-github.com/ethereum/go-ethereum v1.10.8 h1:0UP5WUR8hh46ffbjJV7PK499+uGEyasRIfffS0vy06o=
 github.com/ethereum/go-ethereum v1.10.8/go.mod h1:pJNuIUYfX5+JKzSD/BTdNsvJSZ1TJqmz0dVyXMAbf6M=
 github.com/ethereum/go-ethereum v1.10.13 h1:DEYFP9zk+Gruf3ae1JOJVhNmxK28ee+sMELPLgYTXpA=
 github.com/ethereum/go-ethereum v1.10.13/go.mod h1:W3yfrFyL9C1pHcwY5hmRHVDaorTiQxhYBkKyu5mEDHw=
@@ -575,7 +574,6 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/golang/snappy v0.0.2-0.20200707131729-196ae77b8a26/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.3-0.20201103224600-674baa8c7fc3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -684,6 +682,7 @@ github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyN
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpxn4uE=
 github.com/hashicorp/go-bexpr v0.1.10/go.mod h1:oxlubA2vC/gFVfX1A6JGp7ls7uCDlfJn732ehYYg+g0=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -1002,7 +1001,6 @@ github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q
 github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2viExyCEfeWGU259JnaQ34Inuec4R38JCyBx2edgD0=
 github.com/karalabe/usb v0.0.0-20190819132248-550797b1cad8/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
-github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9 h1:ZHuwnjpP8LsVsUYqTqeVAI+GfDfJ6UNPrExZF+vX/DQ=
 github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/karalabe/usb v0.0.0-20211005121534-4c5740d64559/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/kataras/golog v0.0.9/go.mod h1:12HJgwBIZFNGL0EJnMRhmvGA0PQGx8VFwrZtM4CqbAk=
@@ -1495,6 +1493,7 @@ github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:F
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/pointerstructure v1.2.0 h1:O+i9nHnXS3l/9Wu7r4NrEdwA2VFTicjUEN1uBnDo34A=
 github.com/mitchellh/pointerstructure v1.2.0/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8ohIXc3tViBH44KcwB2g4=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mmcloughlin/avo v0.0.0-20201105074841-5d2f697d268f/go.mod h1:6aKT4zZIrpGqB3RpFU14ByCSSyKY6LfJz4J/JJChHfI=
@@ -1903,7 +1902,6 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/syndtr/goleveldb v1.0.1-0.20190923125748-758128399b1d/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca/go.mod h1:u2MKkTVTVJWe5D1rCvame8WqhBd88EuIwODJZ1VHCPM=
-github.com/syndtr/goleveldb v1.0.1-0.20210305035536-64b5b1c73954 h1:xQdMZ1WLrgkkvOZ/LDQxjVxMLdby7osSh4ZEVa5sIjs=
 github.com/syndtr/goleveldb v1.0.1-0.20210305035536-64b5b1c73954/go.mod h1:u2MKkTVTVJWe5D1rCvame8WqhBd88EuIwODJZ1VHCPM=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
@@ -2097,21 +2095,12 @@ go.vocdoni.io/dvote v0.6.1-0.20210130094936-75dbb92de3f0/go.mod h1:NJyERGs2LmEvl
 go.vocdoni.io/dvote v0.6.1-0.20210206210936-a0407e833753/go.mod h1:HhMMtdnkLI3ujk+zcL1frzFg5S7SbvxWtis7RZTq1dA=
 go.vocdoni.io/dvote v1.0.0/go.mod h1:C9wjSWCzy33Bl2sNiF/2ie/oxcERR3uRD2G2c/NDeH0=
 go.vocdoni.io/dvote v1.0.4-0.20210806163627-9494efbc5382/go.mod h1:kl66EQmAjR252HCRQL756bZQnuvcXZZ3HuaABItf+0E=
-go.vocdoni.io/dvote v1.0.4-0.20211202191118-8fa1a3ae4a54 h1:Rybqk5Ze9ZShr9B3kLbb53VPShi8QCkyT5KLbfVEVWA=
-go.vocdoni.io/dvote v1.0.4-0.20211202191118-8fa1a3ae4a54/go.mod h1:6ZGSgjlJxWobETvqCJ342ebO7FnTI6gFhQsHKh6Owbw=
-go.vocdoni.io/dvote v1.0.4-0.20211205220857-24a0ea848f8d h1:O7BtKrC0PvS+XkjIGjNVvf6eHD78eFeiZWpJrzou5H0=
-go.vocdoni.io/dvote v1.0.4-0.20211205220857-24a0ea848f8d/go.mod h1:6ZGSgjlJxWobETvqCJ342ebO7FnTI6gFhQsHKh6Owbw=
-go.vocdoni.io/dvote v1.0.4-0.20211208183856-3cc820f5d0b2 h1:mIAcgf+8cCGnL/vggkGJvX7EhEDbkLFPXiMEg4IvmCQ=
-go.vocdoni.io/dvote v1.0.4-0.20211208183856-3cc820f5d0b2/go.mod h1:HHhiSQLCWZP2MSQUxdFUlqEWgUf1P24L1OwNiNbeimE=
-go.vocdoni.io/dvote v1.0.4-0.20211209102700-ab5dad159747 h1:wcSALhbLl+tlMC1469wGUc1AVbvO3MYrPsOKg/NMmX0=
-go.vocdoni.io/dvote v1.0.4-0.20211209102700-ab5dad159747/go.mod h1:HHhiSQLCWZP2MSQUxdFUlqEWgUf1P24L1OwNiNbeimE=
 go.vocdoni.io/dvote v1.0.4-0.20211209153702-bc8624f142d8 h1:ncAzMXJb2EU9F87L1NvJmzk7kvyalK/cHwgFITUE8oU=
 go.vocdoni.io/dvote v1.0.4-0.20211209153702-bc8624f142d8/go.mod h1:HHhiSQLCWZP2MSQUxdFUlqEWgUf1P24L1OwNiNbeimE=
 go.vocdoni.io/proto v0.1.7/go.mod h1:cyITrt7+sHmUJH06WLu69xB7LBY9c9FakFaBOe8gs/M=
 go.vocdoni.io/proto v0.1.8/go.mod h1:cyITrt7+sHmUJH06WLu69xB7LBY9c9FakFaBOe8gs/M=
 go.vocdoni.io/proto v0.1.9-0.20210304214308-6f7363b52750/go.mod h1:cyITrt7+sHmUJH06WLu69xB7LBY9c9FakFaBOe8gs/M=
 go.vocdoni.io/proto v1.0.4-0.20210726091234-bceaf416353b/go.mod h1:QV3gKc9Zf0xHW3o8wEaqSn8iZ94UTl8gOzekxoz3kWs=
-go.vocdoni.io/proto v1.13.3-0.20211126083500-46ba146eff3f/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
 go.vocdoni.io/proto v1.13.3-0.20211202161242-17ea8a435be6 h1:ObMJQOAGPOkQouub0EdkRXrkPOjtW6RW41rbdvurdcw=
 go.vocdoni.io/proto v1.13.3-0.20211202161242-17ea8a435be6/go.mod h1:oi/WtiBFJ6QwNDv2aUQYwOnUKzYuS/fBqXF8xDNwcGo=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=

--- a/test/testpgsql/pgsql_election_test.go
+++ b/test/testpgsql/pgsql_election_test.go
@@ -24,7 +24,8 @@ func TestElection(t *testing.T) {
 
 	elections := testcommon.CreateElections(2)
 	id, err := API.DB.CreateElection(integrators[0].SecretApiKey, organizations[0].EthAddress, elections[0].ProcessID,
-		elections[0].Title, elections[0].StartDate, elections[0].EndDate, uuid.NullUUID{}, 0, 0, true, true)
+		elections[0].MetadataPrivKey, elections[0].Title, elections[0].StartDate,
+		elections[0].EndDate, uuid.NullUUID{}, 0, 0, true, true)
 	c.Assert(err, qt.IsNil)
 	c.Assert(int(id), qt.Not(qt.Equals), 0)
 	elections[0].ID = id

--- a/types/api.go
+++ b/types/api.go
@@ -91,6 +91,7 @@ type APIElectionSummary struct {
 	MetadataPrivKey []byte         `json:"metadataPrivKey,omitempty" db:"metadataPrivKey"`
 }
 
+// ProcessMetadata contains the process metadata fields as stored on ipfs
 type ProcessMetadata struct {
 	Description LanguageString        `json:"description,omitempty"`
 	Media       ProcessMedia          `json:"media,omitempty"`
@@ -101,34 +102,36 @@ type ProcessMetadata struct {
 	Version     string                `json:"version,omitempty"`
 }
 
+// LanguageString is a wrapper for multi-language strings, specified in metadata.
+//  example {"default": "hello", "en": "hello", "es": "hola"}
 type LanguageString map[string]string
 
+// ProcessMedia holds the process metadata's header and streamURI
 type ProcessMedia struct {
 	Header    string `json:"header,omitempty"`
 	StreamURI string `json:"streamUri,omitempty"`
 }
 
-type RawFile struct {
-	Payload []byte `json:"payload,omitempty"`
-	Version string `json:"version,omitempty"`
-}
-
+// ProcessResultsDetails describes how a process results should be displayed and aggregated
 type ProcessResultsDetails struct {
 	Aggregation string `json:"aggregation,omitempty"`
 	Display     string `json:"display,omitempty"`
 }
 
+// QuestionMeta contains metadata for one single question of a process
 type QuestionMeta struct {
 	Choices     []Choice       `json:"choices"`
 	Description LanguageString `json:"description"`
 	Title       LanguageString `json:"title"`
 }
 
+// Choice contains metadata for one choice of a question
 type Choice struct {
 	Title LanguageString `json:"title,omitempty"`
 	Value uint32         `json:"value,omitempty"`
 }
 
+// EntityMetadata is the metadata for an organization
 type EntityMetadata struct {
 	Version     string         `json:"version,omitempty"`
 	Languages   []string       `json:"languages,omitempty"`
@@ -140,17 +143,26 @@ type EntityMetadata struct {
 	Actions     interface{}    `json:"actions,omitempty"`
 }
 
+// EntityMedia stores the avatar, header, and logo for an entity metadata
 type EntityMedia struct {
 	Avatar string `json:"avatar,omitempty"`
 	Header string `json:"header,omitempty"`
 	Logo   string `json:"logo,omitempty"`
 }
 
+// VochainResults is the results of a single process, as returned by the vochain
 type VochainResults struct {
 	Height  uint32     `json:"height,omitempty"`
 	Results [][]string `json:"results,omitempty"`
 	State   string     `json:"state,omitempty"`
 	Type    string     `json:"type,omitempty"`
+}
+
+// RawFile provides a json struct wrapper to a raw bytes payload, used for storing
+//  encrypted metadata on ipfs. Version is "1.0"
+type RawFile struct {
+	Payload []byte `json:"payload,omitempty"`
+	Version string `json:"version,omitempty"`
 }
 
 // SetError sets the MetaResponse's Message to a string

--- a/types/api.go
+++ b/types/api.go
@@ -108,6 +108,11 @@ type ProcessMedia struct {
 	StreamURI string `json:"streamUri,omitempty"`
 }
 
+type RawFile struct {
+	Payload []byte `json:"payload,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
 type ProcessResultsDetails struct {
 	Aggregation string `json:"aggregation,omitempty"`
 	Display     string `json:"display,omitempty"`

--- a/types/types.go
+++ b/types/types.go
@@ -43,20 +43,20 @@ type Organization struct {
 }
 
 type Election struct {
-	CreatedUpdated
-	ID               int           `json:"id" db:"id"`
-	OrgEthAddress    []byte        `json:"orgEthAddress" db:"organization_eth_address"`
-	IntegratorApiKey []byte        `json:"integratorApiKey" db:"integrator_api_key"`
-	ProcessID        []byte        `json:"processId" db:"process_id"`
-	Title            string        `json:"title" db:"title"`
-	CensusID         uuid.NullUUID `json:"censusId" db:"census_id"`
-	StartDate        time.Time     `json:"startDate" db:"start_date"`
-	EndDate          time.Time     `json:"endDate" db:"end_date"`
-	StartBlock       int           `json:"startBlock" db:"start_block"`
-	EndBlock         int           `json:"endBlock" db:"end_block"`
-	Confidential     bool          `json:"confidential" db:"confidential"`
-	HiddenResults    bool          `json:"hiddenResults" db:"hidden_results"`
-	MetadataPrivKey  []byte        `json:"metadataPrivKey" db:"metadata_priv_key"`
+	CreatedUpdated   `json:"created_updated,omitempty"`
+	ID               int           `json:"id,omitempty" db:"id"`
+	OrgEthAddress    []byte        `json:"orgEthAddress,omitempty" db:"organization_eth_address"`
+	IntegratorApiKey []byte        `json:"integratorApiKey,omitempty" db:"integrator_api_key"`
+	ProcessID        []byte        `json:"processId,omitempty" db:"process_id"`
+	Title            string        `json:"title,omitempty" db:"title"`
+	CensusID         uuid.NullUUID `json:"censusId,omitempty" db:"census_id"`
+	StartDate        time.Time     `json:"startDate,omitempty" db:"start_date"`
+	EndDate          time.Time     `json:"endDate,omitempty" db:"end_date"`
+	StartBlock       int           `json:"startBlock,omitempty" db:"start_block"`
+	EndBlock         int           `json:"endBlock,omitempty" db:"end_block"`
+	Confidential     bool          `json:"confidential,omitempty" db:"confidential"`
+	HiddenResults    bool          `json:"hiddenResults,omitempty" db:"hidden_results"`
+	MetadataPrivKey  []byte        `json:"metadataPrivKey,omitempty" db:"metadata_priv_key"`
 }
 
 type Result struct {

--- a/types/types.go
+++ b/types/types.go
@@ -43,7 +43,7 @@ type Organization struct {
 }
 
 type Election struct {
-	CreatedUpdated   `json:"created_updated,omitempty"`
+	CreatedUpdated
 	ID               int           `json:"id,omitempty" db:"id"`
 	OrgEthAddress    []byte        `json:"orgEthAddress,omitempty" db:"organization_eth_address"`
 	IntegratorApiKey []byte        `json:"integratorApiKey,omitempty" db:"integrator_api_key"`

--- a/urlapi/entity.go
+++ b/urlapi/entity.go
@@ -608,7 +608,7 @@ func (u *URLAPI) getProcessHandler(
 	// Fetch election from database
 	dbElection, err := u.db.GetElection(integratorApiKey, vochainProcess.EntityID, processId)
 	if err != nil {
-		return fmt.Errorf("could not get election from the database")
+		return fmt.Errorf("could not get election from the database: %w", err)
 	}
 
 	// Fetch results

--- a/urlapi/entity.go
+++ b/urlapi/entity.go
@@ -598,7 +598,8 @@ func (u *URLAPI) getProcessHandler(
 	}
 	if vochainProcess == nil {
 		return fmt.Errorf("process does not exist")
-		
+	}
+
 	integratorApiKey, err := hex.DecodeString(msg.AuthToken)
 	if err != nil {
 		return fmt.Errorf("could not decode bearer token: %w", err)
@@ -644,7 +645,6 @@ func (u *URLAPI) getProcessHandler(
 	if err != nil {
 		return fmt.Errorf("could not parse information for process %x: %w", processId, err)
 	}
-
 	return sendResponse(resp, ctx)
 }
 

--- a/urlapi/entity.go
+++ b/urlapi/entity.go
@@ -595,6 +595,12 @@ func (u *URLAPI) getProcessHandler(
 		return fmt.Errorf("process does not exist")
 	}
 
+	// Fetch election from database
+	dbElection, err := u.db.GetElectionPublic(vochainProcess.EntityID, processId)
+	if err != nil {
+		return fmt.Errorf("could not get election from the database")
+	}
+
 	// Fetch results
 	var results *types.VochainResults
 	if vochainProcess.HaveResults {
@@ -604,9 +610,25 @@ func (u *URLAPI) getProcessHandler(
 	}
 
 	// Fetch metadata
-	processMetadata, err := u.vocClient.FetchProcessMetadata(vochainProcess.Metadata)
-	if err != nil {
-		return fmt.Errorf("could not get process metadata: %w", err)
+	var processMetadata *types.ProcessMetadata
+	if dbElection.Confidential {
+		metaKey := dbElection.MetadataPrivKey
+		// If globalMetadataKey exists, try to decrypt metadata private key
+		if len(u.globalMetadataKey) < 0 {
+			var ok bool
+			metaKey, ok = util.DecryptSymmetric(dbElection.MetadataPrivKey, u.globalMetadataKey)
+			if !ok {
+				return fmt.Errorf("could not decrypt election private metadata key")
+			}
+		}
+		if processMetadata, err = u.vocClient.FetchProcessMetadataConfidential(
+			vochainProcess.Metadata, metaKey); err != nil {
+			return fmt.Errorf("could not get process metadata: %w", err)
+		}
+	} else {
+		if processMetadata, err = u.vocClient.FetchProcessMetadata(vochainProcess.Metadata); err != nil {
+			return fmt.Errorf("could not get process metadata: %w", err)
+		}
 	}
 	// Parse all the information
 	resp, err := u.parseProcessInfo(vochainProcess, results, processMetadata)

--- a/urlapi/entity.go
+++ b/urlapi/entity.go
@@ -492,8 +492,8 @@ func (u *URLAPI) createProcessHandler(msg *bearerstdapi.BearerStandardAPIdata,
 			return fmt.Errorf("could not decode metadata private key: %w", err)
 		}
 		// Encrypt and send the process metadata
-		if metaUri, err = u.vocClient.SetProcessMetadataConfidential(
-			metadata, metaPrivKeyBytes, processID); err != nil {
+		if metaUri, err = u.vocClient.SetProcessMetadata(
+			metadata, processID, metaPrivKeyBytes); err != nil {
 			return fmt.Errorf("could not set confidential process metadata: %w", err)
 		}
 
@@ -506,7 +506,7 @@ func (u *URLAPI) createProcessHandler(msg *bearerstdapi.BearerStandardAPIdata,
 		}
 
 	} else { // Process is not confidential, no need to touch metadata key
-		if metaUri, err = u.vocClient.SetProcessMetadata(metadata, processID); err != nil {
+		if metaUri, err = u.vocClient.SetProcessMetadata(metadata, processID, []byte{}); err != nil {
 			return fmt.Errorf("could not set process metadata: %w", err)
 		}
 	}
@@ -541,7 +541,7 @@ func (u *URLAPI) createProcessHandler(msg *bearerstdapi.BearerStandardAPIdata,
 
 	// TODO fetch actual transaction hash
 	txHash := dvoteutil.RandomHex(32)
-	u.txWaitMap.Store(txHash, time.Now())
+	u.txWaitMap.Store(txHash, time.Now().Add(time.Duration(2*int(avgTimes[0]))))
 	u.dbTransactions.Store(txHash, createElectionQuery{
 		integratorPrivKey: orgInfo.integratorPrivKey,
 		ethAddress:        orgInfo.entityID,

--- a/urlapi/public.go
+++ b/urlapi/public.go
@@ -1,11 +1,13 @@
 package urlapi
 
 import (
+	"bytes"
 	"encoding/base64"
 	"fmt"
 
 	"go.vocdoni.io/api/types"
 	"go.vocdoni.io/api/util"
+	"go.vocdoni.io/dvote/crypto/ethereum"
 	"go.vocdoni.io/dvote/httprouter"
 	"go.vocdoni.io/dvote/httprouter/bearerstdapi"
 	"go.vocdoni.io/dvote/log"
@@ -129,6 +131,15 @@ func (u *URLAPI) getProcessInfoPublicHandler(msg *bearerstdapi.BearerStandardAPI
 		}
 	}
 
+	dbElection, err := u.db.GetElectionPublic(vochainProcess.EntityID, processId)
+	if err != nil {
+		return fmt.Errorf("could not fetch election %x from db: %w", processId, err)
+	}
+
+	if dbElection.Confidential {
+		return fmt.Errorf("process %x is confidential, use authenticated API", processId)
+	}
+
 	// Fetch metadata
 	processMetadata, err := u.vocClient.FetchProcessMetadata(vochainProcess.Metadata)
 	if err != nil {
@@ -149,7 +160,58 @@ func (u *URLAPI) getProcessInfoPublicHandler(msg *bearerstdapi.BearerStandardAPI
 //  checking the voter's signature for inclusion in the census
 func (u *URLAPI) getProcessInfoConfidentialHandler(msg *bearerstdapi.BearerStandardAPIdata,
 	ctx *httprouter.HTTPContext) error {
-	return fmt.Errorf("endpoint %s unimplemented", ctx.Request.URL.String())
+	processId, err := util.GetBytesID(ctx, "electionId")
+	if err != nil {
+		return err
+	}
+	cspSignature, err := util.GetBytesID(ctx, "signature")
+	if err != nil {
+		return err
+	}
+
+	// Fetch process from vochain
+	vochainProcess, err := u.vocClient.GetProcess(processId)
+	if err != nil {
+		return fmt.Errorf("unable to get process: %w", err)
+	}
+
+	// Fetch results
+	var results *types.VochainResults
+	if vochainProcess.HaveResults {
+		if results, err = u.vocClient.GetResults(processId); err != nil {
+			return fmt.Errorf("unable to get results %w", err)
+		}
+	}
+
+	dbElection, err := u.db.GetElectionPublic(vochainProcess.EntityID, processId)
+	if err != nil {
+		return fmt.Errorf("could not fetch election %x from db: %w", processId, err)
+	}
+	integrator, err := u.db.GetIntegratorByKey(dbElection.IntegratorApiKey)
+	if err != nil {
+		return fmt.Errorf("could not fetch election's integrator from db: %w", err)
+	}
+	cspPubKey, err := ethereum.PubKeyFromSignature(processId, cspSignature)
+	if err != nil {
+		return fmt.Errorf("could not extract csp pubKey from signature: %w", err)
+	}
+	if !bytes.Equal(cspPubKey, integrator.CspPubKey) {
+		return fmt.Errorf("signature pubKey %x does not match integrator's csp pubKey %x", cspPubKey, integrator.CspPubKey)
+	}
+
+	// Fetch metadata
+	processMetadata, err := u.vocClient.FetchProcessMetadata(vochainProcess.Metadata)
+	if err != nil {
+		return fmt.Errorf("unable to get metadata: %w", err)
+	}
+
+	// Parse all the information
+	resp, err := u.parseProcessInfo(vochainProcess, results, processMetadata)
+	if err != nil {
+		return fmt.Errorf("could not parse information for process %x: %w", processId, err)
+	}
+
+	return sendResponse(resp, ctx)
 }
 
 // GET https://server/v1/pub/account/organizations/<organizationId>

--- a/urlapi/public.go
+++ b/urlapi/public.go
@@ -183,7 +183,7 @@ func (u *URLAPI) getProcessInfoConfidentialHandler(msg *bearerstdapi.BearerStand
 		}
 	}
 
-	dbElection, err := u.db.GetElectionPublic(vochainProcess.EntityID, processId)
+	dbElection, err := u.db.GetElectionPrivate(vochainProcess.EntityID, processId)
 	if err != nil {
 		return fmt.Errorf("could not fetch election %x from db: %w", processId, err)
 	}

--- a/urlapi/txhash.go
+++ b/urlapi/txhash.go
@@ -33,6 +33,7 @@ type createElectionQuery struct {
 	integratorPrivKey []byte
 	ethAddress        []byte
 	electionID        []byte
+	encryptedMetaKey  []byte
 	title             string
 	startDate         time.Time
 	endDate           time.Time
@@ -86,10 +87,9 @@ func (u *URLAPI) getTxStatusHandler(msg *bearerstdapi.BearerStandardAPIdata,
 			return fmt.Errorf("could not update organization: %w", err)
 		}
 	case createElectionQuery:
-		if _, err = u.db.CreateElection(queryTx.integratorPrivKey, queryTx.ethAddress,
-			queryTx.electionID, queryTx.title, queryTx.startDate, queryTx.endDate,
-			queryTx.censusID, queryTx.startBlock, queryTx.endBlock, queryTx.confidential,
-			queryTx.hiddenResults); err != nil {
+		if _, err = u.db.CreateElection(queryTx.integratorPrivKey, queryTx.ethAddress, queryTx.electionID, queryTx.encryptedMetaKey,
+			queryTx.title, queryTx.startDate, queryTx.endDate, queryTx.censusID, queryTx.startBlock, queryTx.endBlock,
+			queryTx.confidential, queryTx.hiddenResults); err != nil {
 			return fmt.Errorf("could not create election: %w", err)
 		}
 	}

--- a/urlapi/urlapi.go
+++ b/urlapi/urlapi.go
@@ -73,10 +73,9 @@ func NewURLAPI(router *httprouter.HTTProuter,
 	if len(cfg.GlobalMetaKey) > 0 {
 		key, err := hex.DecodeString(cfg.GlobalMetaKey)
 		if err != nil {
-			log.Errorf("could not decode global metadata key: %v", err)
-		} else {
-			urlapi.globalMetadataKey = key
+			log.Fatalf("could not decode global metadata key: %v", err)
 		}
+		urlapi.globalMetadataKey = key
 		log.Infof("global metadata encryption key: %x", urlapi.globalMetadataKey)
 	}
 	urlapi.registerMetrics()

--- a/urlapi/urlapi.go
+++ b/urlapi/urlapi.go
@@ -77,7 +77,7 @@ func NewURLAPI(router *httprouter.HTTProuter,
 		} else {
 			urlapi.globalMetadataKey = key
 		}
-		log.Infof("global metadata encryption key: %s", key)
+		log.Infof("global metadata encryption key: %x", urlapi.globalMetadataKey)
 	}
 	urlapi.registerMetrics()
 	var err error

--- a/urlapi/urlapi.go
+++ b/urlapi/urlapi.go
@@ -25,12 +25,13 @@ type URLAPI struct {
 	BaseRoute    string
 
 	config                *config.API
+	globalOrganizationKey []byte
+	globalMetadataKey     []byte
 	router                *httprouter.HTTProuter
 	api                   *bearerstdapi.BearerStandardAPI
 	metricsagent          *metrics.Agent
 	db                    database.Database
 	vocClient             *vocclient.Client
-	globalOrganizationKey []byte
 	// Map of database queries pending transactions being mined
 	dbTransactions sync.Map
 	// TODO remove temporary tx time map
@@ -68,6 +69,15 @@ func NewURLAPI(router *httprouter.HTTProuter,
 			urlapi.globalOrganizationKey = key
 		}
 		log.Infof("global entity encryption key: %s", key)
+	}
+	if len(cfg.GlobalMetaKey) > 0 {
+		key, err := hex.DecodeString(cfg.GlobalMetaKey)
+		if err != nil {
+			log.Errorf("could not decode global metadata key: %v", err)
+		} else {
+			urlapi.globalMetadataKey = key
+		}
+		log.Infof("global metadata encryption key: %s", key)
 	}
 	urlapi.registerMetrics()
 	var err error

--- a/urlapi/util.go
+++ b/urlapi/util.go
@@ -39,7 +39,8 @@ func (u *URLAPI) authEntityPermissions(msg *bearerstdapi.BearerStandardAPIdata,
 			fmt.Errorf("organization %s could not be fetched from the db: %w", organizationID.String(), err)
 	}
 	// if !bytes.Equal(organization.IntegratorApiKey, integratorPrivKey) {
-	// 	return orgPermissionsInfo{}, fmt.Errorf("entity %s does not belong to this integrator", organizationID.String())
+	// 	return orgPermissionsInfo{}, fmt.Errorf(
+	// "entity %s does not belong to this integrator", organizationID.String())
 	// }
 	return orgPermissionsInfo{
 		integratorPrivKey: integratorPrivKey,

--- a/vocclient/vocclient.go
+++ b/vocclient/vocclient.go
@@ -345,6 +345,7 @@ func (c *Client) FetchProcessMetadataConfidential(URI string,
 	if err != nil {
 		return nil, err
 	}
+
 	decrypted, ok := apiUtil.DecryptSymmetric(content, metadataPrivKey)
 	if !ok {
 		return nil, fmt.Errorf("could not decrypt private metadata")

--- a/vocclient/vocclient.go
+++ b/vocclient/vocclient.go
@@ -293,7 +293,7 @@ func (c *Client) SetProcessMetadataConfidential(meta types.ProcessMetadata, meta
 	if err != nil {
 		return "", fmt.Errorf("could not marshal process metadata: %v", err)
 	}
-	log.Debugf("encrypting meta with %x", metadataPrivKey)
+	log.Debugf("encrypting metatadata for %x", processId)
 	encryptedMeta, err := apiUtil.EncryptSymmetric(metaBytes, metadataPrivKey)
 	if err != nil {
 		return "", fmt.Errorf("could not encrypt private metadata: %w", err)


### PR DESCRIPTION
- store privateMetadataKey in elections in the db
- global config option for a key to encrypt the privateMetadataKey for each election 
- encrypt & pin metadata for private processes
- fetch & decrypt private metadata for calls authenticated with integrator api token
- also decrypt private metadata for calls with csp signature