### PR TITLE
Fix near-future process bug

### DIFF
--- a/urlapi/entity.go
+++ b/urlapi/entity.go
@@ -543,9 +543,11 @@ func (u *URLAPI) createProcessHandler(msg *bearerstdapi.BearerStandardAPIdata,
 	}
 
 	currentBlockHeight, avgTimes, _ := u.vocClient.GetBlockTimes()
+
+	// If process starting within the vochain margin, just set it to start immediately.
+	// Otherwise there could be an error of startBlock > currentHeight
 	if startBlock > 1 && startBlock < currentBlockHeight+vocclient.VOCHAIN_BLOCK_MARGIN {
-		return fmt.Errorf("cannot create process: startDate needs to be at least %ds in the future",
-			vocclient.VOCHAIN_BLOCK_MARGIN*avgTimes[0]/1000)
+		startBlock = 0
 	}
 
 	blockCount := endBlock - startBlock


### PR DESCRIPTION
This pr fixed a bug where occasionally, in testing, a process would be created in the very near future. This would cause the `startBlock`to be non-zero but very close to the vochain block height, which could result in an error. 

Now, the `startBlock` is simply set to zero so the process starts immediately.